### PR TITLE
bugfix in trim and trim_left: "str.match" -> "string.match"

### DIFF
--- a/init.fnl
+++ b/init.fnl
@@ -150,11 +150,11 @@ end"))
 
 (defn anise.trim [s pat]
   (local pat (or pat "%s*"))
-  (str.match s (f-str "^{pat}(.-){pat}$")))
+  (string.match s (f-str "^{pat}(.-){pat}$")))
 
 (defn anise.trim_left [s pat]
   (local pat (or pat "%s+"))
-  (str.match s (f-str "^{pat}(.*)$")))
+  (string.match s (f-str "^{pat}(.*)$")))
 
 ;; custom data structures
 
@@ -260,5 +260,5 @@ end"))
   } anise.set_meta))
 
 ;; end
- 
+
 anise


### PR DESCRIPTION
(: s :match ...) would work as well, and it's slightly more concise, but it would err more vaguely if `s` was not a string. Current behavior supports numbers; using s:match would not. However, there's no reason to pass a number to a string-trimming function. Nowhere else in the file is `:` used instead of `string.foo`, so I did not make that change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bb010g/anise/1)
<!-- Reviewable:end -->
